### PR TITLE
Fix bug when creating the [Requests] directory under [app/Http] when the path [app/Http/Requests] does not exist

### DIFF
--- a/src/Services/PathsAndNamespacesService.php
+++ b/src/Services/PathsAndNamespacesService.php
@@ -82,7 +82,7 @@ class PathsAndNamespacesService
 
     public function getRealpathBaseRequest()
     {
-        return $this->getRealpathBase('app'.DIRECTORY_SEPARATOR.'Http'.DIRECTORY_SEPARATOR.'Requests');
+        return $this->getRealpathBase('app'.DIRECTORY_SEPARATOR.'Http').DIRECTORY_SEPARATOR.'Requests';
     }
 
     public function getRealpathBaseCustomRequest($namingConvention)


### PR DESCRIPTION

When trying to create the directory [**app/Http/Requests**], the code `$this->getRealpathBase('app'.DIRECTORY_SEPARATOR.'Http'.DIRECTORY_SEPARATOR.'Requests')` returns false (since app/Http/Requests does not exist).

The following code will return the correct path `$this->getRealpathBase('app'.DIRECTORY_SEPARATOR.'Http').DIRECTORY_SEPARATOR.'Requests'`